### PR TITLE
シーン移動直後にキャラクター切り替えすると以降Akimが動けなくなる #187

### DIFF
--- a/Assets/Scripts/Control/PartyCongroller.cs
+++ b/Assets/Scripts/Control/PartyCongroller.cs
@@ -10,7 +10,7 @@ using System;
 
 namespace VLCNP.Control
 {
-    public class PartyCongroller : MonoBehaviour, IJsonSaveable
+    public class PartyCongroller : MonoBehaviour, IJsonSaveable, IStoppable
     {
         [SerializeField] GameObject currentPlayer;
         [SerializeField] GameObject[] members;
@@ -22,6 +22,10 @@ namespace VLCNP.Control
         [SerializeField] FlagManager flagManager;
         [SerializeField]
         CinemachineVirtualCamera virtualCamera;
+
+        bool isStopped = false;
+        public bool IsStopped { get => isStopped; set => isStopped = value; }
+
         public event Action<GameObject> OnChangeCharacter;
 
         private void Awake()
@@ -66,6 +70,7 @@ namespace VLCNP.Control
 
         private void Update()
         {
+            if (isStopped) return;
             if (Input.GetKeyDown(KeyCode.A) || Input.GetKeyDown(KeyCode.S))
             {
                 SwitchNextPlayer();


### PR DESCRIPTION
移動直後に切り替えると、StoppableControllerで停止したAkimが、再開されない
下記の対処を行った

* PartyControllerにIStoppableを導入し、移動直後にキャラクター切り替えを行えないようにした