### PR TITLE
ジャンプ力調整ができるようにする #257

### DIFF
--- a/Assets/Game/Characters/Party.prefab
+++ b/Assets/Game/Characters/Party.prefab
@@ -55,7 +55,6 @@ MonoBehaviour:
   hpBar: {fileID: 0}
   experienceBar: {fileID: 0}
   levelDisplay: {fileID: 0}
-  gameOver: {fileID: 0}
   flagManager: {fileID: 0}
   virtualCamera: {fileID: 0}
 --- !u!114 &7366152789054923333
@@ -85,6 +84,10 @@ PrefabInstance:
     - target: {fileID: 1699767717115717140, guid: 305b768f10cad4098b6aad1149350872, type: 3}
       propertyPath: m_Name
       value: Akim
+      objectReference: {fileID: 0}
+    - target: {fileID: 3433531399435260855, guid: 305b768f10cad4098b6aad1149350872, type: 3}
+      propertyPath: m_GravityScale
+      value: 1.5
       objectReference: {fileID: 0}
     - target: {fileID: 6362254506045297432, guid: 305b768f10cad4098b6aad1149350872, type: 3}
       propertyPath: m_RootOrder
@@ -196,6 +199,10 @@ PrefabInstance:
     - target: {fileID: 2904360697236049413, guid: 305b768f10cad4098b6aad1149350872, type: 3}
       propertyPath: animationsPerLevels.Array.data[0].colliderPerLevel.capsuleCollider2DYSize
       value: 2.4
+      objectReference: {fileID: 0}
+    - target: {fileID: 3433531399435260855, guid: 305b768f10cad4098b6aad1149350872, type: 3}
+      propertyPath: m_GravityScale
+      value: 1.5
       objectReference: {fileID: 0}
     - target: {fileID: 3552741078913666834, guid: 305b768f10cad4098b6aad1149350872, type: 3}
       propertyPath: m_Offset.x

--- a/Assets/Game/Characters/Player.prefab
+++ b/Assets/Game/Characters/Player.prefab
@@ -257,7 +257,7 @@ PrefabInstance:
       objectReference: {fileID: 6200000, guid: 898c69a6bf67c45a1add6b56271c659e, type: 2}
     - target: {fileID: -2641368885610136209, guid: b53f7de505ed44dce9641241aeeba081, type: 3}
       propertyPath: m_GravityScale
-      value: 1.75
+      value: 1.5
       objectReference: {fileID: 0}
     - target: {fileID: -1001761984920063403, guid: b53f7de505ed44dce9641241aeeba081, type: 3}
       propertyPath: audioClip
@@ -407,6 +407,64 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   uniqueIdentifier: player
+--- !u!114 &2277831187227911215
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1699767717115717140}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5b31ea3ccb2494e3f9e7c767e392784e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  leg: {fileID: 3487292076679122934}
+  jumpPower: 7
+  minJumpPower: 2
+  maxJumpTime: 0.3
+  jumpCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 2
+      outSlope: 2
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0
+      outWeight: 0
+    - serializedVersion: 3
+      time: 0.009858742
+      value: 0.1711325
+      inSlope: 11.356025
+      outSlope: 11.356025
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 1
+      outWeight: 0.33333334
+    - serializedVersion: 3
+      time: 0.053472184
+      value: 0.48838308
+      inSlope: 1.9050717
+      outSlope: 1.9050717
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.8217394
+      outWeight: 0.33333334
+    - serializedVersion: 3
+      time: 1
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0
+      outWeight: 0
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
 --- !u!114 &2904360697236049413
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -483,64 +541,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   experiencePoints: 0
   loseExperienceModifier: 2
---- !u!114 &2277831187227911215
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1699767717115717140}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 5b31ea3ccb2494e3f9e7c767e392784e, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  leg: {fileID: 3487292076679122934}
-  jumpPower: 7.5
-  minJumpPower: 2
-  maxJumpTime: 0.3
-  jumpCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 0
-      inSlope: 2
-      outSlope: 2
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0
-      outWeight: 0
-    - serializedVersion: 3
-      time: 0.022845753
-      value: 0.16876544
-      inSlope: 3.9440067
-      outSlope: 3.9440067
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 1
-      outWeight: 0.33333334
-    - serializedVersion: 3
-      time: 0.09243322
-      value: 0.5025854
-      inSlope: 1.9050717
-      outSlope: 1.9050717
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.8217394
-      outWeight: 0.33333334
-    - serializedVersion: 3
-      time: 1
-      value: 1
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0
-      outWeight: 0
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
 --- !u!4 &6362254506045297432 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 3223142059203919296, guid: b53f7de505ed44dce9641241aeeba081, type: 3}

--- a/Assets/Game/Characters/Player.prefab
+++ b/Assets/Game/Characters/Player.prefab
@@ -40,6 +40,8 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 5760476965117826515}
+  - component: {fileID: 3461051795355800905}
+  - component: {fileID: 3487292076679122934}
   m_Layer: 3
   m_Name: Leg
   m_TagString: Untagged
@@ -62,6 +64,44 @@ Transform:
   m_Father: {fileID: 6362254506045297432}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!61 &3461051795355800905
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3154311684208112230}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0, y: 0}
+    oldSize: {x: 0, y: 0}
+    newSize: {x: 0, y: 0}
+    adaptiveTilingThreshold: 0
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 0.49, y: 0.12}
+  m_EdgeRadius: 0
+--- !u!114 &3487292076679122934
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3154311684208112230}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 95d66326a866b4c6a8efeee3e9818d7d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &5408824604639863246
 GameObject:
   m_ObjectHideFlags: 0
@@ -215,6 +255,10 @@ PrefabInstance:
       propertyPath: m_Material
       value: 
       objectReference: {fileID: 6200000, guid: 898c69a6bf67c45a1add6b56271c659e, type: 2}
+    - target: {fileID: -2641368885610136209, guid: b53f7de505ed44dce9641241aeeba081, type: 3}
+      propertyPath: m_GravityScale
+      value: 1.75
+      objectReference: {fileID: 0}
     - target: {fileID: -1001761984920063403, guid: b53f7de505ed44dce9641241aeeba081, type: 3}
       propertyPath: audioClip
       value: 
@@ -439,6 +483,64 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   experiencePoints: 0
   loseExperienceModifier: 2
+--- !u!114 &2277831187227911215
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1699767717115717140}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5b31ea3ccb2494e3f9e7c767e392784e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  leg: {fileID: 3487292076679122934}
+  jumpPower: 7.5
+  minJumpPower: 2
+  maxJumpTime: 0.3
+  jumpCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 2
+      outSlope: 2
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0
+      outWeight: 0
+    - serializedVersion: 3
+      time: 0.022845753
+      value: 0.16876544
+      inSlope: 3.9440067
+      outSlope: 3.9440067
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 1
+      outWeight: 0.33333334
+    - serializedVersion: 3
+      time: 0.09243322
+      value: 0.5025854
+      inSlope: 1.9050717
+      outSlope: 1.9050717
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.8217394
+      outWeight: 0.33333334
+    - serializedVersion: 3
+      time: 1
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0
+      outWeight: 0
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
 --- !u!4 &6362254506045297432 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 3223142059203919296, guid: b53f7de505ed44dce9641241aeeba081, type: 3}

--- a/Assets/Scenes/Ohirunebeya_5_boss.unity
+++ b/Assets/Scenes/Ohirunebeya_5_boss.unity
@@ -35705,10 +35705,6 @@ PrefabInstance:
       propertyPath: m_Constraints
       value: 4
       objectReference: {fileID: 0}
-    - target: {fileID: 1963697600864285482, guid: 011494565755b490386e78a113e3c871, type: 3}
-      propertyPath: m_GravityScale
-      value: 1
-      objectReference: {fileID: 0}
     - target: {fileID: 2515792094813851658, guid: 011494565755b490386e78a113e3c871, type: 3}
       propertyPath: Loop
       value: 1

--- a/Assets/Scenes/Ohirunebeya_start.unity
+++ b/Assets/Scenes/Ohirunebeya_start.unity
@@ -497,74 +497,6 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 3564026850829729314, guid: 70e4f80265d902443a6249697d613d81, type: 3}
   m_PrefabInstance: {fileID: 337483516}
   m_PrefabAsset: {fileID: 0}
---- !u!1 &150947086
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 150947089}
-  - component: {fileID: 150947088}
-  - component: {fileID: 150947087}
-  m_Layer: 0
-  m_Name: EventSystem
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!114 &150947087
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 150947086}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4f231c4fb786f3946a6b90b886c48677, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_SendPointerHoverToParent: 1
-  m_HorizontalAxis: Horizontal
-  m_VerticalAxis: Vertical
-  m_SubmitButton: Submit
-  m_CancelButton: Cancel
-  m_InputActionsPerSecond: 10
-  m_RepeatDelay: 0.5
-  m_ForceModuleActive: 0
---- !u!114 &150947088
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 150947086}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 76c392e42b5098c458856cdf6ecaaaa1, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_FirstSelected: {fileID: 0}
-  m_sendNavigationEvents: 1
-  m_DragThreshold: 10
---- !u!4 &150947089
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 150947086}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_RootOrder: 4
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &162343733
 GameObject:
   m_ObjectHideFlags: 0
@@ -597,7 +529,7 @@ Transform:
   - {fileID: 1321009214}
   - {fileID: 14740103}
   m_Father: {fileID: 0}
-  m_RootOrder: 7
+  m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &191429430
 GameObject:
@@ -3314,7 +3246,7 @@ Transform:
   - {fileID: 951616184}
   - {fileID: 461591278}
   m_Father: {fileID: 0}
-  m_RootOrder: 6
+  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &461591278 stripped
 Transform:
@@ -3527,7 +3459,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6310595414258977201, guid: 1f1f77daf42324f128d5ed5216b39b32, type: 3}
       propertyPath: m_RootOrder
-      value: 8
+      value: 7
       objectReference: {fileID: 0}
     - target: {fileID: 6310595414258977201, guid: 1f1f77daf42324f128d5ed5216b39b32, type: 3}
       propertyPath: m_LocalPosition.x
@@ -15485,7 +15417,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 5
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1922658117
 GameObject:
@@ -15703,7 +15635,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7760567091349314552, guid: b8548fdfaab164f03ac8dfe88baad183, type: 3}
       propertyPath: m_RootOrder
-      value: 9
+      value: 8
       objectReference: {fileID: 0}
     - target: {fileID: 7760567091349314552, guid: b8548fdfaab164f03ac8dfe88baad183, type: 3}
       propertyPath: m_AnchorMax.x

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -369,7 +369,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7221854999727932486, guid: 88a125effb1a84db0990f6b057088a34, type: 3}
       propertyPath: m_RootOrder
-      value: 18
+      value: 17
       objectReference: {fileID: 0}
     - target: {fileID: 7221854999727932486, guid: 88a125effb1a84db0990f6b057088a34, type: 3}
       propertyPath: m_LocalPosition.x
@@ -550,7 +550,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 9
+  m_RootOrder: 8
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &603898119
 MonoBehaviour:
@@ -6020,74 +6020,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 3a0bbe22c246e4c78ad8e9816cbae9d5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!1 &1058074322
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1058074325}
-  - component: {fileID: 1058074324}
-  - component: {fileID: 1058074323}
-  m_Layer: 0
-  m_Name: EventSystem
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!114 &1058074323
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1058074322}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4f231c4fb786f3946a6b90b886c48677, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_SendPointerHoverToParent: 1
-  m_HorizontalAxis: Horizontal
-  m_VerticalAxis: Vertical
-  m_SubmitButton: Submit
-  m_CancelButton: Cancel
-  m_InputActionsPerSecond: 10
-  m_RepeatDelay: 0.5
-  m_ForceModuleActive: 0
---- !u!114 &1058074324
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1058074322}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 76c392e42b5098c458856cdf6ecaaaa1, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_FirstSelected: {fileID: 0}
-  m_sendNavigationEvents: 1
-  m_DragThreshold: 10
---- !u!4 &1058074325
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1058074322}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_RootOrder: 8
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1101510462
 GameObject:
   m_ObjectHideFlags: 0
@@ -6211,7 +6143,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 16
+  m_RootOrder: 15
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1141898532
 GameObject:
@@ -6338,7 +6270,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 19
+  m_RootOrder: 18
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1152804466
 PrefabInstance:
@@ -6471,7 +6403,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 1941707417193288842, guid: edadb4021f4c844c9871fb7ca32451d2, type: 3}
       propertyPath: m_RootOrder
-      value: 21
+      value: 20
       objectReference: {fileID: 0}
     - target: {fileID: 1941707417193288842, guid: edadb4021f4c844c9871fb7ca32451d2, type: 3}
       propertyPath: m_LocalPosition.x
@@ -6532,7 +6464,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 1941707417193288842, guid: edadb4021f4c844c9871fb7ca32451d2, type: 3}
       propertyPath: m_RootOrder
-      value: 15
+      value: 14
       objectReference: {fileID: 0}
     - target: {fileID: 1941707417193288842, guid: edadb4021f4c844c9871fb7ca32451d2, type: 3}
       propertyPath: m_LocalPosition.x
@@ -6627,7 +6559,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 10
+  m_RootOrder: 9
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1673424985
 PrefabInstance:
@@ -6699,7 +6631,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 1941707417193288842, guid: edadb4021f4c844c9871fb7ca32451d2, type: 3}
       propertyPath: m_RootOrder
-      value: 22
+      value: 21
       objectReference: {fileID: 0}
     - target: {fileID: 1941707417193288842, guid: edadb4021f4c844c9871fb7ca32451d2, type: 3}
       propertyPath: m_LocalPosition.x
@@ -7084,7 +7016,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 14
+  m_RootOrder: 13
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &1836443559 stripped
 MonoBehaviour:
@@ -7201,7 +7133,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 24
+  m_RootOrder: 23
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &1870180382
 MonoBehaviour:
@@ -7377,7 +7309,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 12
+  m_RootOrder: 11
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!61 &1871434428
 BoxCollider2D:
@@ -7455,7 +7387,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 1941707417193288842, guid: edadb4021f4c844c9871fb7ca32451d2, type: 3}
       propertyPath: m_RootOrder
-      value: 13
+      value: 12
       objectReference: {fileID: 0}
     - target: {fileID: 1941707417193288842, guid: edadb4021f4c844c9871fb7ca32451d2, type: 3}
       propertyPath: m_LocalPosition.x
@@ -7516,7 +7448,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 1941707417193288842, guid: edadb4021f4c844c9871fb7ca32451d2, type: 3}
       propertyPath: m_RootOrder
-      value: 20
+      value: 19
       objectReference: {fileID: 0}
     - target: {fileID: 1941707417193288842, guid: edadb4021f4c844c9871fb7ca32451d2, type: 3}
       propertyPath: m_LocalPosition.x
@@ -7577,7 +7509,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 1941707417193288842, guid: edadb4021f4c844c9871fb7ca32451d2, type: 3}
       propertyPath: m_RootOrder
-      value: 11
+      value: 10
       objectReference: {fileID: 0}
     - target: {fileID: 1941707417193288842, guid: edadb4021f4c844c9871fb7ca32451d2, type: 3}
       propertyPath: m_LocalPosition.x
@@ -7682,7 +7614,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 976885865057812764, guid: fbb78368ef33c44faa030963b129d648, type: 3}
       propertyPath: m_RootOrder
-      value: 23
+      value: 22
       objectReference: {fileID: 0}
     - target: {fileID: 976885865057812764, guid: fbb78368ef33c44faa030963b129d648, type: 3}
       propertyPath: m_LocalPosition.x
@@ -7868,7 +7800,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 17
+  m_RootOrder: 16
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &6448916648448277117
 MonoBehaviour:
@@ -8181,5 +8113,185 @@ PrefabInstance:
       propertyPath: defaultWeaponConfig
       value: 
       objectReference: {fileID: 11400000, guid: 5c58eb1f0190245e4b4c3c21c543306e, type: 2}
+    - target: {fileID: 8887748786286564010, guid: 011494565755b490386e78a113e3c871, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8887748786286564010, guid: 011494565755b490386e78a113e3c871, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8887748786286564010, guid: 011494565755b490386e78a113e3c871, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8887748786286564010, guid: 011494565755b490386e78a113e3c871, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8887748786286564010, guid: 011494565755b490386e78a113e3c871, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8887748786286564010, guid: 011494565755b490386e78a113e3c871, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8887748786718537233, guid: 011494565755b490386e78a113e3c871, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8887748786901004433, guid: 011494565755b490386e78a113e3c871, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8887748786901004433, guid: 011494565755b490386e78a113e3c871, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8887748787036601566, guid: 011494565755b490386e78a113e3c871, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8887748787036601566, guid: 011494565755b490386e78a113e3c871, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8887748787036601566, guid: 011494565755b490386e78a113e3c871, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8887748787036601566, guid: 011494565755b490386e78a113e3c871, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8887748787036601566, guid: 011494565755b490386e78a113e3c871, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8887748787036601566, guid: 011494565755b490386e78a113e3c871, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8887748787177837649, guid: 011494565755b490386e78a113e3c871, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8887748787177837649, guid: 011494565755b490386e78a113e3c871, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8887748787177837649, guid: 011494565755b490386e78a113e3c871, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8887748787177837649, guid: 011494565755b490386e78a113e3c871, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8887748787177837649, guid: 011494565755b490386e78a113e3c871, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8887748787177837649, guid: 011494565755b490386e78a113e3c871, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8887748787448295856, guid: 011494565755b490386e78a113e3c871, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8887748787448295856, guid: 011494565755b490386e78a113e3c871, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8887748787448295856, guid: 011494565755b490386e78a113e3c871, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8887748787448295856, guid: 011494565755b490386e78a113e3c871, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8887748787448295856, guid: 011494565755b490386e78a113e3c871, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8887748787448295856, guid: 011494565755b490386e78a113e3c871, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8887748787481497282, guid: 011494565755b490386e78a113e3c871, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8887748787481497282, guid: 011494565755b490386e78a113e3c871, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8887748787481497282, guid: 011494565755b490386e78a113e3c871, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8887748787481497282, guid: 011494565755b490386e78a113e3c871, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8887748787481497282, guid: 011494565755b490386e78a113e3c871, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8887748787481497282, guid: 011494565755b490386e78a113e3c871, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8887748787833423855, guid: 011494565755b490386e78a113e3c871, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8887748787833423855, guid: 011494565755b490386e78a113e3c871, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8887748787833423855, guid: 011494565755b490386e78a113e3c871, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8887748787833423855, guid: 011494565755b490386e78a113e3c871, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8887748787833423855, guid: 011494565755b490386e78a113e3c871, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8887748787833423855, guid: 011494565755b490386e78a113e3c871, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8887748787924953009, guid: 011494565755b490386e78a113e3c871, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8887748787924953009, guid: 011494565755b490386e78a113e3c871, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8887748787924953009, guid: 011494565755b490386e78a113e3c871, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8887748787924953009, guid: 011494565755b490386e78a113e3c871, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8887748787924953009, guid: 011494565755b490386e78a113e3c871, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8887748787924953009, guid: 011494565755b490386e78a113e3c871, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 011494565755b490386e78a113e3c871, type: 3}

--- a/Assets/Scripts/Movement/Jump.cs
+++ b/Assets/Scripts/Movement/Jump.cs
@@ -8,22 +8,34 @@ namespace VLCNP.Movement
     {
         [SerializeField] Leg leg;
         Rigidbody2D rBody;
-        // 一度ジャンプ押してからまだジャンプボタンを離していない
         bool isJumping = false;
+        // ジャンプボタンが押しっぱなしかどうか。押しっぱなしで連続ジャンプはしない
+        bool isJumpButtonKeep = false;
 
-        [SerializeField, Min(0)] float jumpPower = 7;
-        [SerializeField, Min(0)] float minJumpPower = 2;
+        [SerializeField, Min(0)] float jumpPower = 7.5f;
+        [SerializeField, Min(0)] float minJumpPower = 2f;
         float jumpTime = 0;
-        [SerializeField, Min(0)] float maxJumpTime = 1f;
+        [SerializeField, Min(0)] float maxJumpTime = 0.3f;
         [SerializeField] AnimationCurve jumpCurve = new();
 
         private void Awake()
         {
             rBody = GetComponent<Rigidbody2D>();
+            leg.OnLanded += OnLanded;
         }
 
         void Update()
         {
+            // ジャンプボタン押しっぱなしの場合は一度離さないとジャンプできない
+            if (Input.GetKeyUp("space"))
+            {
+                isJumpButtonKeep = false;
+            }
+            if (isJumpButtonKeep)
+            {
+                return;
+            }
+
             // ジャンプの開始判定
             if (leg.IsGround && Input.GetKey("space"))
             {
@@ -41,6 +53,15 @@ namespace VLCNP.Movement
                 {
                     jumpTime += Time.deltaTime;
                 }
+            }
+        }
+
+        private void OnLanded()
+        {
+            // 着地時にジャンプボタン押しっぱなしの場合はジャンプボタン押しっぱなしと判定
+            if (Input.GetKey("space"))
+            {
+                isJumpButtonKeep = true;
             }
         }
 

--- a/Assets/Scripts/Movement/Jump.cs
+++ b/Assets/Scripts/Movement/Jump.cs
@@ -1,0 +1,75 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace VLCNP.Movement
+{
+    public class Jump : MonoBehaviour
+    {
+        [SerializeField] Leg leg;
+        Rigidbody2D rBody;
+        // 一度ジャンプ押してからまだジャンプボタンを離していない
+        bool isJumping = false;
+
+        [SerializeField, Min(0)] float jumpPower = 7;
+        [SerializeField, Min(0)] float minJumpPower = 2;
+        float jumpTime = 0;
+        [SerializeField, Min(0)] float maxJumpTime = 1f;
+        [SerializeField] AnimationCurve jumpCurve = new();
+
+        private void Awake()
+        {
+            rBody = GetComponent<Rigidbody2D>();
+        }
+
+        void Update()
+        {
+            // ジャンプの開始判定
+            if (leg.IsGround && Input.GetKey("space"))
+            {
+                isJumping = true;
+            }
+            // ジャンプ中の処理
+            if (isJumping)
+            {
+                if (Input.GetKeyUp("space") || jumpTime >= maxJumpTime)
+                {
+                    isJumping = false;
+                    jumpTime = 0;
+                }
+                else if (Input.GetKey("space"))
+                {
+                    jumpTime += Time.deltaTime;
+                }
+            }
+        }
+
+        private void FixedUpdate()
+        {
+            DoJump();
+        }
+
+        private void DoJump()
+        {
+            if (!isJumping)
+            {
+                return;
+            }
+
+            rBody.velocity = new Vector2(rBody.velocity.x, 0);
+
+            // ジャンプの速度をアニメーションカーブから取得
+            float t = jumpTime / maxJumpTime;
+            float power = jumpPower * jumpCurve.Evaluate(t);
+            // 最低ジャンプ力を保証
+            power = Mathf.Max(power, minJumpPower);
+            if (t >= 1)
+            {
+                isJumping = false;
+                jumpTime = 0;
+            }
+
+            rBody.AddForce(power * Vector2.up, ForceMode2D.Impulse);
+        }
+    }
+}

--- a/Assets/Scripts/Movement/Jump.cs.meta
+++ b/Assets/Scripts/Movement/Jump.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5b31ea3ccb2494e3f9e7c767e392784e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Movement/Leg.cs
+++ b/Assets/Scripts/Movement/Leg.cs
@@ -1,0 +1,31 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace VLCNP.Movement
+{
+    public class Leg : MonoBehaviour
+    {
+        bool isGround = false;
+
+        public bool IsGround { get => isGround; set => isGround = value; }
+
+        private void OnTriggerStay2D(Collider2D collision)
+        {
+            if (!collision.tag.Equals("Ground") && !collision.tag.Equals("Enemy"))
+            {
+                return;
+            }
+            IsGround = true;
+        }
+
+        private void OnTriggerExit2D(Collider2D collision)
+        {
+            if (!collision.tag.Equals("Ground") && !collision.tag.Equals("Enemy"))
+            {
+                return;
+            }
+            IsGround = false;
+        }
+    }
+}

--- a/Assets/Scripts/Movement/Leg.cs
+++ b/Assets/Scripts/Movement/Leg.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
@@ -9,6 +10,9 @@ namespace VLCNP.Movement
         bool isGround = false;
 
         public bool IsGround { get => isGround; set => isGround = value; }
+
+        // 着地したときのイベント
+        public event Action OnLanded;
 
         private void OnTriggerStay2D(Collider2D collision)
         {
@@ -26,6 +30,14 @@ namespace VLCNP.Movement
                 return;
             }
             IsGround = false;
+        }
+
+        private void OnTriggerEnter2D(Collider2D collision)
+        {
+            if ((collision.tag.Equals("Ground") || collision.tag.Equals("Enemy")) && !IsGround)
+            {
+                OnLanded?.Invoke();
+            }
         }
     }
 }

--- a/Assets/Scripts/Movement/Leg.cs.meta
+++ b/Assets/Scripts/Movement/Leg.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 95d66326a866b4c6a8efeee3e9818d7d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Movement/Mover.cs
+++ b/Assets/Scripts/Movement/Mover.cs
@@ -107,7 +107,6 @@ namespace VLCNP.Movement
             // Stun状態の場合は移動不可
             if (isStunned()) return;
             UpdateMoveSpeed();
-            // UpdateJumpState();
             UpdateCharacterDirection();
         }
 
@@ -144,20 +143,6 @@ namespace VLCNP.Movement
             {
                 transform.localScale = new Vector3(-1 * Mathf.Abs(transform.localScale.x), transform.localScale.y, transform.localScale.z);
             }
-        }
-
-        private void UpdateJumpState()
-        {
-            if (isJumping)
-            {
-                isJumping = false;
-                Jump(jumpPower);
-            }
-        }
-
-        public void Jump(float _jumpPower = 2)
-        {
-            rbody.AddForce(new Vector2(0, _jumpPower), ForceMode2D.Impulse);
         }
     }
 }

--- a/Assets/Scripts/Movement/Mover.cs
+++ b/Assets/Scripts/Movement/Mover.cs
@@ -12,16 +12,17 @@ namespace VLCNP.Movement
         [SerializeField] float jumpPower = 7;
         bool isLeft = true;
         // isLeftのgetterを定義
-        public bool IsLeft { get => isLeft;  set => isLeft = value;}
+        public bool IsLeft { get => isLeft; set => isLeft = value; }
         bool isGround = true;
-        bool isJumping= false;
+        bool isJumping = false;
         bool isPushing = false;
         float vx = 0;
         Rigidbody2D rbody;
         Animator animator;
         PlayerStun playerStun;
 
-        private void Awake() {
+        private void Awake()
+        {
             rbody = GetComponent<Rigidbody2D>();
             animator = GetComponent<Animator>();
             playerStun = GetComponent<PlayerStun>();
@@ -92,7 +93,7 @@ namespace VLCNP.Movement
         private bool CanJump()
         {
             // 地面についていて、ジャンプボタン押しっぱなしでない、かつ、上向きの速度が0.1以下
-            return  isGround && !isPushing && rbody.velocity.y < 0.1f;
+            return isGround && !isPushing && rbody.velocity.y < 0.1f;
         }
 
         private void UpdateAnimator()
@@ -106,7 +107,7 @@ namespace VLCNP.Movement
             // Stun状態の場合は移動不可
             if (isStunned()) return;
             UpdateMoveSpeed();
-            UpdateJumpState();
+            // UpdateJumpState();
             UpdateCharacterDirection();
         }
 
@@ -158,5 +159,5 @@ namespace VLCNP.Movement
         {
             rbody.AddForce(new Vector2(0, _jumpPower), ForceMode2D.Impulse);
         }
-    }    
+    }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新機能**
    - ジャンプ機能を追加し、滑らかなジャンプメカニクスとコントロールを実現する`Jump`スクリプトを導入しました。
    - `Leg`クラスを導入し、2D環境で「地面」または「敵」とタグ付けされたオブジェクトとのトリガー相互作用に基づいて`isGround`フラグを管理します。
    
- **ドキュメント**
    - Unityシーンファイル`Ohirunebeya_start.unity`のプロパティの変更を反映しました。主に複数のインスタンスで`m_RootOrder`値を1減少させる調整が含まれます。
    - Unityシーンファイル`SampleScene.unity`の`Transform`と`PrefabInstance`オブジェクトの複数のインスタンスで`m_RootOrder`プロパティ値の変更を反映しました。それぞれの値を1減少させました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->