### PR TITLE
連打するだけでドラァグに勝てる #412

### DIFF
--- a/Assets/Game/Resources/DragGatotu.asset
+++ b/Assets/Game/Resources/DragGatotu.asset
@@ -14,5 +14,5 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   equieppedPrefab: {fileID: 0}
   weaponLevels:
-  - damage: 3
+  - damage: 4
     projectile: {fileID: 0}

--- a/Assets/Game/Stats/Progression.asset
+++ b/Assets/Game/Stats/Progression.asset
@@ -67,4 +67,4 @@ MonoBehaviour:
     stats:
     - stat: 0
       levels:
-      - 150
+      - 200

--- a/Assets/Scenes/VeryLongFarm_1_boss_4.unity
+++ b/Assets/Scenes/VeryLongFarm_1_boss_4.unity
@@ -3242,7 +3242,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3537494708198848658, guid: fbb78368ef33c44faa030963b129d648, type: 3}
       propertyPath: selectedCommands.Array.size
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3537494708198848658, guid: fbb78368ef33c44faa030963b129d648, type: 3}
       propertyPath: selectedBlocks.Array.data[0]
@@ -3258,7 +3258,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5307012217563610202, guid: fbb78368ef33c44faa030963b129d648, type: 3}
       propertyPath: nodeRect.y
-      value: 75
+      value: 76
       objectReference: {fileID: 0}
     - target: {fileID: 5307012217563610202, guid: fbb78368ef33c44faa030963b129d648, type: 3}
       propertyPath: nodeRect.width
@@ -3266,7 +3266,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5307012217563610202, guid: fbb78368ef33c44faa030963b129d648, type: 3}
       propertyPath: commandList.Array.size
-      value: 30
+      value: 31
       objectReference: {fileID: 0}
     - target: {fileID: 5307012217563610202, guid: fbb78368ef33c44faa030963b129d648, type: 3}
       propertyPath: commandList.Array.data[0]
@@ -3383,15 +3383,15 @@ PrefabInstance:
     - target: {fileID: 5307012217563610202, guid: fbb78368ef33c44faa030963b129d648, type: 3}
       propertyPath: commandList.Array.data[28]
       value: 
-      objectReference: {fileID: 542368229}
+      objectReference: {fileID: 542368248}
     - target: {fileID: 5307012217563610202, guid: fbb78368ef33c44faa030963b129d648, type: 3}
       propertyPath: commandList.Array.data[29]
       value: 
-      objectReference: {fileID: 542368245}
+      objectReference: {fileID: 542368229}
     - target: {fileID: 5307012217563610202, guid: fbb78368ef33c44faa030963b129d648, type: 3}
       propertyPath: commandList.Array.data[30]
       value: 
-      objectReference: {fileID: 0}
+      objectReference: {fileID: 542368245}
     - target: {fileID: 5307012217563610202, guid: fbb78368ef33c44faa030963b129d648, type: 3}
       propertyPath: commandList.Array.data[31]
       value: 
@@ -4458,7 +4458,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   itemId: 25
   indentLevel: 0
-  storyText: "\u541B\u306E\u6F5C\u5728\u7684\u306A\u9577\u3055\u3092\n\u6700\u5927\u9650\u307E\u3067\u5F15\u304D\u4F38\u3070\u3057\u305F\uFF01\uFF01"
+  storyText: "\u305D\u308C\u306F\u50D5\u304C\u958B\u767A\u3057\u305F\u300C\u8679\u306E\u7A2E\u300D...\uFF01\n\u30A2\u30CB\u30DE\u30EB\u306E\u6F5C\u5728\u80FD\u529B\u3092\u5F15\u304D\u51FA\u3059\n\u79D8\u5BC6\u306E\u6ECB\u990A\u5F37\u58EE\u5264\u3060\uFF01"
   description: 
   character: {fileID: 109252888}
   portrait: {fileID: 21300000, guid: 2b3dee63346a14909b619113629b5dad, type: 3}
@@ -4787,6 +4787,33 @@ MonoBehaviour:
   soundClip: {fileID: 8300000, guid: ee1ba78107941484ba2666e4f75947d8, type: 3}
   volume: 1
   waitUntilFinished: 0
+--- !u!114 &542368248
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 542368199}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ec422cd568a9c4a31ad7c36d0572b9da, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  itemId: 40
+  indentLevel: 0
+  storyText: "\u541B\u306E\u6F5C\u5728\u7684\u306A\u9577\u3055\u3092\n\u6700\u5927\u9650\u307E\u3067\u5F15\u304D\u4F38\u3070\u3057\u305F\uFF01\uFF01"
+  description: 
+  character: {fileID: 109252888}
+  portrait: {fileID: 21300000, guid: 2b3dee63346a14909b619113629b5dad, type: 3}
+  voiceOverClip: {fileID: 0}
+  showAlways: 1
+  showCount: 1
+  extendPrevious: 0
+  fadeWhenDone: 1
+  waitForClick: 1
+  stopVoiceover: 1
+  waitForVO: 0
+  setSayDialog: {fileID: 0}
 --- !u!1001 &578521899
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -37027,7 +37054,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 61dddfdc5e0e44ca298d8f46f7f5a915, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  selectedFlowchart: {fileID: 2051503805}
+  selectedFlowchart: {fileID: 542368200}
 --- !u!4 &1903074192
 Transform:
   m_ObjectHideFlags: 1

--- a/Assets/Scripts/Combat/EnemyWeapon/AttachedWeapon.cs
+++ b/Assets/Scripts/Combat/EnemyWeapon/AttachedWeapon.cs
@@ -14,9 +14,19 @@ namespace VLCNP.Combat.EnemyWeapon
         private void OnTriggerEnter2D(Collider2D other)
         {
             if (!other.gameObject.CompareTag(targetTagName)) return;
-            Health health = other.gameObject.GetComponent<Health>();
+            Attack(other.gameObject.GetComponent<Health>());
+        }
+
+        private void OnTriggerStay2D(Collider2D other)
+        {
+            if (!other.gameObject.CompareTag(targetTagName)) return;
+            Attack(other.gameObject.GetComponent<Health>());
+        }
+
+        private void Attack(Health health)
+        {
             if (health == null) return;
             health.TakeDamage(weaponConfig.GetDamage());
-        }
+        }  
     }
 }

--- a/Assets/Scripts/Control/PartyCongroller.cs
+++ b/Assets/Scripts/Control/PartyCongroller.cs
@@ -187,6 +187,8 @@ namespace VLCNP.Control
         {
             // 位置を前のキャラに合わせる
             nextPlayer.transform.position = currentPlayer.transform.position;
+            // 向きを前のキャラに合わせる
+            nextPlayer.GetComponent<Mover>().IsLeft = currentPlayer.GetComponent<Mover>().IsLeft;
             // 前のキャラの足の位置の高さ取得
             float previousFootPositionY = currentPlayer.transform.Find("Leg").localPosition.y;
             // 次のキャラの足の位置の高さ取得


### PR DESCRIPTION
* ドラァグのHPを少しあげる
* 牙突のダメージを少しあげる
* 牙突、接触開始時にダメージ判定はあったが、接触中にダメージ判定がなかったため追加。これによりひっついたままだと大ダメージを受ける
* キャラ切替時、向きを引き継がせる