### PR TITLE
feat: Akimレベル3オーラのフラグ制御機能を実装

### DIFF
--- a/Assets/Characters/Player/Script/AuraController.cs
+++ b/Assets/Characters/Player/Script/AuraController.cs
@@ -1,0 +1,95 @@
+using UnityEngine;
+using VLCNP.Core;
+
+public class AuraController : MonoBehaviour
+{
+    private ParticleSystem auraParticleSystem;
+    private FlagManager flagManager;
+    private bool isInitialized = false;
+
+    private void Start()
+    {
+        Initialize();
+    }
+
+    private void Initialize()
+    {
+        // ParticleSystemコンポーネントを取得
+        auraParticleSystem = GetComponent<ParticleSystem>();
+        if (auraParticleSystem == null)
+        {
+            Debug.LogError("AuraController: ParticleSystem component not found!");
+            return;
+        }
+
+        // FlagManagerを探して取得
+        flagManager = FindObjectOfType<FlagManager>();
+        if (flagManager == null)
+        {
+            Debug.LogError("AuraController: FlagManager not found!");
+            return;
+        }
+
+        // フラグ変更イベントを監視
+        flagManager.OnChangeFlag += OnFlagChanged;
+
+        // 初期状態をチェック
+        UpdateAuraVisibility();
+
+        isInitialized = true;
+    }
+
+    private void OnDestroy()
+    {
+        // イベントの購読を解除
+        if (flagManager != null)
+        {
+            flagManager.OnChangeFlag -= OnFlagChanged;
+        }
+    }
+
+    private void OnFlagChanged(Flag flag, bool value)
+    {
+        // NoEnemiesフラグの変更のみを監視
+        if (flag == Flag.NoEnemies)
+        {
+            UpdateAuraVisibility();
+        }
+    }
+
+    private void UpdateAuraVisibility()
+    {
+        if (!isInitialized || auraParticleSystem == null || flagManager == null)
+        {
+            return;
+        }
+
+        bool noEnemies = flagManager.GetFlag(Flag.NoEnemies);
+        
+        if (noEnemies)
+        {
+            // 敵がいない場合はパーティクルシステムを停止
+            if (auraParticleSystem.isPlaying)
+            {
+                auraParticleSystem.Stop();
+            }
+        }
+        else
+        {
+            // 敵がいる場合はパーティクルシステムを再生
+            if (!auraParticleSystem.isPlaying)
+            {
+                auraParticleSystem.Play();
+            }
+        }
+    }
+
+    // 外部からオーラの可視性を強制更新するためのメソッド
+    public void ForceUpdateVisibility()
+    {
+        if (isInitialized)
+        {
+            UpdateAuraVisibility();
+        }
+    }
+}

--- a/Assets/Characters/Player/Script/PlayerLevel.cs
+++ b/Assets/Characters/Player/Script/PlayerLevel.cs
@@ -116,6 +116,13 @@ public class PlayerLevel : MonoBehaviour, ILevel
         // xに−0.26, yに-0.62の位置に表示
         _aura = Instantiate(aura, transform.position, Quaternion.identity, transform);
         _aura.transform.localPosition = new Vector3(-0.26f, -0.62f, 0);
+        
+        // AuraControllerコンポーネントを追加してオーラの表示制御を有効にする
+        AuraController auraController = _aura.GetComponent<AuraController>();
+        if (auraController == null)
+        {
+            auraController = _aura.AddComponent<AuraController>();
+        }
     }
     private void removeAura()
     {

--- a/Assets/DocsForAI/Design/AkimLevel3AuraControlDesign.md
+++ b/Assets/DocsForAI/Design/AkimLevel3AuraControlDesign.md
@@ -1,0 +1,100 @@
+# Akimレベル3オーラ制御機能設計書
+
+## 概要
+Akimがレベル3のときに表示されるオーラを、「敵がいない」フラグの状態に応じて動的に制御する機能の設計書。
+
+## 実装されたコンポーネント
+
+### 1. Flag.cs の拡張
+- 新しいフラグ `NoEnemies` を追加
+- 既存のセーブデータとの互換性を保つため、enum の末尾に追加
+
+### 2. AuraController クラス
+**ファイル**: `Assets/Characters/Player/Script/AuraController.cs`
+
+**責任**:
+- オーラのParticle Systemの表示/非表示を制御
+- FlagManagerのフラグ変更イベントを監視
+- NoEnemiesフラグの状態に応じてパーティクルシステムを制御
+
+**主要メソッド**:
+- `Initialize()`: 初期化処理（ParticleSystem取得、FlagManager取得、イベント監視開始）
+- `OnFlagChanged()`: フラグ変更イベントハンドラ
+- `UpdateAuraVisibility()`: オーラの表示状態を更新
+- `ForceUpdateVisibility()`: 外部からの強制更新用メソッド
+
+**設計の特徴**:
+- 単一責任の原則に従い、オーラ制御のみに特化
+- エラーハンドリングを含む堅牢な実装
+- メモリリークを防ぐためのイベント購読解除
+
+### 3. PlayerLevel.cs の修正
+**変更点**:
+- `instantiateAura()` メソッドでAuraControllerコンポーネントを自動追加
+- オーラ制御ロジックをAuraControllerに委譲
+
+## 動作フロー
+
+1. **オーラ生成時**:
+   - PlayerLevelがレベル3になる
+   - `instantiateAura()` でオーラオブジェクトが生成される
+   - 自動的にAuraControllerコンポーネントが追加される
+
+2. **フラグ監視**:
+   - AuraControllerがFlagManagerのOnChangeFlagイベントを監視
+   - NoEnemiesフラグの変更を検知
+
+3. **オーラ制御**:
+   - NoEnemies = true → パーティクルシステム停止
+   - NoEnemies = false → パーティクルシステム再生
+
+## Unity Editor での設定
+
+### 前提条件
+- オーラPrefabにParticleSystemコンポーネントが含まれていること
+- FlagManagerがシーンに存在すること
+
+### 自動設定される項目
+- AuraControllerコンポーネントの追加（コードで自動実行）
+- ParticleSystemコンポーネントの参照取得（コードで自動実行）
+- FlagManagerの参照取得（コードで自動実行）
+
+### 手動設定が必要な項目
+なし（全て自動で設定される）
+
+## 使用方法
+
+### フラグの設定
+```csharp
+// 敵がいない状態にする
+flagManager.SetFlag(Flag.NoEnemies, true);
+
+// 敵がいる状態にする
+flagManager.SetFlag(Flag.NoEnemies, false);
+```
+
+### 強制更新（必要に応じて）
+```csharp
+// オーラオブジェクトのAuraControllerから強制更新
+auraController.ForceUpdateVisibility();
+```
+
+## エラーハンドリング
+
+- ParticleSystemが見つからない場合のエラーログ出力
+- FlagManagerが見つからない場合のエラーログ出力
+- コンポーネント破棄時のイベント購読解除
+- 初期化前の処理呼び出しに対する安全な処理
+
+## 拡張性
+
+### 将来的な拡張ポイント
+1. 他のフラグによるオーラ制御の追加
+2. オーラのエフェクトレベル調整
+3. フェードイン・フェードアウトアニメーション
+4. 音響エフェクトの同期制御
+
+### 設計の利点
+- 単一責任の原則により、他のオーラ関連機能の追加が容易
+- イベント駆動設計により、フラグシステムとの疎結合を実現
+- エラーハンドリングにより運用時の安定性を確保

--- a/Assets/DocsForAI/Plan/AkimLevel3AuraControl.md
+++ b/Assets/DocsForAI/Plan/AkimLevel3AuraControl.md
@@ -1,0 +1,45 @@
+# Akimレベル3オーラ制御機能の実装プラン
+
+## 概要
+Akimがレベル3のときに表示されるオーラを、「敵がいない」フラグの状態に応じて制御する機能を実装する。
+
+## 要件
+1. 「敵がいない」フラグがONのとき、オーラのparticle systemを停止する
+2. 「敵がいない」フラグがOFFのとき、オーラのparticle systemを再開する
+3. 単一責任の原則を守った設計にする
+
+## 実装計画
+
+### 1. フラグの追加
+- `Assets/Scripts/Core/Flag.cs`に`NoEnemies`フラグを追加
+- 既存のセーブデータ互換性のため、末尾に追加
+
+### 2. オーラ制御クラスの作成
+- `AuraController`クラスを新規作成
+- 責任：オーラのParticle Systemの制御
+- FlagManagerからのイベントを監視
+- PlayerLevelクラスから独立させて単一責任の原則を守る
+
+### 3. PlayerLevelクラスの修正
+- オーラ制御ロジックを`AuraController`に委譲
+- オーラインスタンス作成時に`AuraController`をアタッチ
+
+### 4. 実装の流れ
+1. Flag.csに新しいフラグを追加
+2. AuraControllerクラスを作成
+3. PlayerLevel.csを修正してAuraControllerを使用
+4. Unity Editorでの設定方法をドキュメント化
+
+## 技術的詳細
+
+### AuraControllerの設計
+```csharp
+// AuraController
+- ParticleSystem参照を保持
+- FlagManagerのOnChangeFlagイベントを監視
+- NoEnemiesフラグの変更に応じてParticleSystemの再生/停止を制御
+```
+
+### PlayerLevelクラスの変更点
+- instantiateAura()メソッド内でAuraControllerコンポーネントを追加
+- オーラの制御ロジックはAuraControllerに移譲

--- a/Assets/Scripts/Core/Flag.cs
+++ b/Assets/Scripts/Core/Flag.cs
@@ -32,5 +32,6 @@ namespace VLCNP.Core
         OhiruneBeyaTutiTyukan, // お昼寝部屋土の中間地点に到達した
         VLOrochiJoined, // オロチが仲間になった
         HPUpAfterVLOrochiJoined, // オロチ加入後のHPアップ
+        NoEnemies, // 敵がいない
     }
 }


### PR DESCRIPTION
Akimのレベル3時のオーラを「敵がいない」フラグに応じて制御する機能を実装

## 変更内容
- NoEnemiesフラグを追加
- AuraControllerクラスを新規作成してオーラ表示制御を実装
- 敵がいないフラグON時にパーティクルシステムを停止

## 技術的特徴
- 単一責任の原則に従った設計
- イベント駆動設計で疎結合を実現
- Unity Editorでの手動設定不要

Closes #525

Generated with [Claude Code](https://claude.ai/code)