### PR TITLE
[codex] VLミタマボスのテレポート高さを固定

### DIFF
--- a/Assets/Game/Characters/Enemy/VLMitamaBoss.prefab
+++ b/Assets/Game/Characters/Enemy/VLMitamaBoss.prefab
@@ -520,6 +520,7 @@ MonoBehaviour:
   - {fileID: 0}
   - {fileID: 0}
   - {fileID: 0}
+  ignorePlayerRelativeY: 1
   targetRenderers: []
   targetCanvasGroups: []
   targetColliders: []

--- a/Assets/Scripts/Combat/EnemyAction/TeleportAction.cs
+++ b/Assets/Scripts/Combat/EnemyAction/TeleportAction.cs
@@ -19,6 +19,9 @@ namespace VLCNP.Combat.EnemyAction
         float minimumTeleportDistance = 2f;
 
         [SerializeField]
+        bool ignorePlayerRelativeY = false;
+
+        [SerializeField]
         SpriteRenderer[] targetRenderers = null;
 
         [SerializeField]
@@ -446,6 +449,10 @@ namespace VLCNP.Combat.EnemyAction
 
             Vector3 relativePosition = point.position - teleportPointsCenter.position;
             Vector3 destination = player.position + relativePosition;
+            if (ignorePlayerRelativeY)
+            {
+                destination.y = point.position.y;
+            }
             destination.z = point.position.z;
             return destination;
         }


### PR DESCRIPTION
## 概要

- VLMitamaBoss のテレポート先計算で、プレイヤーの現在 Y 座標を使わない設定を追加しました。
- `TeleportAction` に `ignorePlayerRelativeY` を追加し、true の場合は X のみプレイヤー相対、Y はテレポートポイントのワールド Y を維持します。
- `Assets/Game/Characters/Enemy/VLMitamaBoss.prefab` の TeleportAction だけ `ignorePlayerRelativeY: 1` にしています。

## 背景

従来は `player.position + (teleportPoint - teleportPointsCenter)` で X/Y ともプレイヤー相対になっていました。
そのため、プレイヤーがジャンプ中にテレポートが発生すると、闇堕ちVLミタマの出現位置もジャンプ分だけ高くなっていました。

今回の修正で、テレポートポイント自体の高さは維持しつつ、プレイヤーのジャンプ高さには追従しないようにしています。

## 影響範囲

- デフォルト値は `false` のため、他の TeleportAction 利用箇所の既存挙動は変わりません。
- VLMitamaBoss は X 方向のプレイヤー相対配置を維持し、Y 方向だけ固定点基準になります。

## 検証

- `unicli exec AssetDatabase.Import --path "Assets/Game/Characters/Enemy/VLMitamaBoss.prefab" --json`
- `unicli exec AssetDatabase.Import --path "Assets/Scripts/Combat/EnemyAction/TeleportAction.cs" --json`
- `unicli exec Compile --json`
- `git diff --check`

Unity compile はエラー 0 で成功しています。既存 warning は出ています。手動プレイ確認は未実施です。